### PR TITLE
Change ruby-mysql path resolve method

### DIFF
--- a/vendor/plugins/joruri_plugin/lib/extend_ruby_mysql.rb
+++ b/vendor/plugins/joruri_plugin/lib/extend_ruby_mysql.rb
@@ -10,7 +10,7 @@
 #  end
 class Mysql
 
-  dir = "/usr/local/lib/ruby/gems/1.9.1/gems/ruby-mysql-2.9.4/lib"
+  dir = (Gem::GemPathSearcher.new).find("mysql").full_gem_path + "/lib"
   require "#{dir}/mysql/constants"
   require "#{dir}/mysql/error"
   require "#{dir}/mysql/charset"


### PR DESCRIPTION
フルパス決め打ちではなくGemPathSearcherを用いていただけると
環境の揺れを吸収しやすいので助かります。

下記事例ではrvm利用時にエラーになりシンボリックリンクで解決されています。
Joruri Mailをインストールしてみる | Mi's Blog, https://blog.mi2428.net/install-joruri/